### PR TITLE
Increase window widths so values are fully displayed by default.

### DIFF
--- a/Software/RF2DFieldSolver/Scenarios/scenario.ui
+++ b/Software/RF2DFieldSolver/Scenarios/scenario.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>711</width>
+    <width>1111</width>
     <height>361</height>
    </rect>
   </property>

--- a/Software/RF2DFieldSolver/mainwindow.ui
+++ b/Software/RF2DFieldSolver/mainwindow.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>990</width>
+    <width>1139</width>
     <height>1089</height>
    </rect>
   </property>


### PR DESCRIPTION
On FreeBSD with qt 6.11.1 the windows don't fully show the values until I grab a corner to resize them.
Changing the default widths is a bit more convenient rather then having to manually resize them all the time.
I realize different people on different platforms with different monitors may have different experiences.