### PR TITLE
Default to slightly smaller grid.

### DIFF
--- a/Software/RF2DFieldSolver/mainwindow.cpp
+++ b/Software/RF2DFieldSolver/mainwindow.cpp
@@ -35,7 +35,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->resolution->setUnit("m");
     ui->resolution->setPrefixes("um ");
     ui->resolution->setPrecision(4);
-    ui->resolution->setValue(10e-6);
+    ui->resolution->setValue(4e-6);
 
     ui->gaussDistance->setUnit("m");
     ui->gaussDistance->setPrefixes("um ");


### PR DESCRIPTION
I find it useful to default to a slightly smaller grid (as noted in the old discussion regarding
differential microstrip discrepancy).  I realize there's no one answer which fits everyone's
use case and this requires more resources so may not be an appropriate change for everyone.